### PR TITLE
Add container item check-in workflow

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -69,6 +69,9 @@ def init_db():
         override_by TEXT,                        -- (opsional) siapa yang setujui
         voided_at TEXT,                          -- jika dibatalkan (mis-scan)
         void_reason TEXT,                        -- alasan void
+        returned_at TEXT,                        -- waktu kembali
+        return_condition TEXT,                   -- good | rusak_ringan | rusak_berat
+        damage_note TEXT,                        -- catatan kerusakan saat kembali
         FOREIGN KEY(container_id) REFERENCES containers(id),
         FOREIGN KEY(id_code) REFERENCES item_unit(id_code)
     );
@@ -82,6 +85,9 @@ def init_db():
             ("override_by", "TEXT"),
             ("voided_at", "TEXT"),
             ("void_reason", "TEXT"),
+            ("returned_at", "TEXT"),
+            ("return_condition", "TEXT"),
+            ("damage_note", "TEXT"),
         ]
     }
     for table, cols in need_cols.items():

--- a/backend/routes_containers.py
+++ b/backend/routes_containers.py
@@ -66,6 +66,7 @@ def _build_detail(conn, cid):
     rows = conn.execute("""
         SELECT ci.id, ci.id_code, ci.added_at, ci.batch_label, ci.condition_at_checkout,
                ci.override_reason, ci.voided_at,
+               ci.returned_at, ci.return_condition, ci.damage_note,
                iu.name, iu.model, iu.rack
         FROM container_item ci
         LEFT JOIN item_unit iu ON iu.id_code = ci.id_code
@@ -87,7 +88,10 @@ def _build_detail(conn, cid):
             "rack": d.get("rack"),
             "added_at": d["added_at"],
             "condition": d.get("condition_at_checkout") or "good",
-            "reason": d.get("override_reason") or ""
+            "reason": d.get("override_reason") or "",
+            "returned_at": d.get("returned_at"),
+            "return_condition": d.get("return_condition"),
+            "damage_note": d.get("damage_note"),
         })
         cond = (d.get("condition_at_checkout") or "good")
         if cond in totals:
@@ -225,6 +229,59 @@ def void_item(cid):
         # void + revert item status -> Good
         conn.execute("UPDATE container_item SET voided_at=?, void_reason=? WHERE id=?", (now_iso(), reason, row["id"]))
         conn.execute("UPDATE item_unit SET status='Good' WHERE id_code=?", (id_code,))
+        conn.commit()
+        return jsonify({"ok": True})
+    finally:
+        conn.close()
+
+# ---------- Check-in item ----------
+@bp.post("/<cid>/checkin")
+@auth_required
+def checkin_item(cid):
+    b = request.get_json(silent=True) or {}
+    id_code = (b.get("id_code") or "").strip()
+    condition = (b.get("condition") or "good").strip()
+    note = (b.get("damage_note") or "").strip()
+
+    if not id_code:
+        return jsonify({"error": True, "message": "id_code wajib"}), 400
+    if condition not in ("good", "rusak_ringan", "rusak_berat"):
+        return jsonify({"error": True, "message": "condition tidak valid"}), 400
+
+    conn = get_conn()
+    try:
+        row = conn.execute("""
+            SELECT id FROM container_item
+            WHERE container_id=? AND id_code=? AND voided_at IS NULL
+        """, (cid, id_code)).fetchone()
+        if not row:
+            return jsonify({"error": True, "message": "Item tidak aktif di kontainer"}), 404
+
+        conn.execute(
+            "UPDATE container_item SET returned_at=?, return_condition=?, damage_note=? WHERE id=?",
+            (now_iso(), condition, note or None, row["id"]),
+        )
+
+        if condition == "good":
+            conn.execute(
+                "UPDATE item_unit SET status='Good', defect_level='none' WHERE id_code=?",
+                (id_code,),
+            )
+        else:
+            level = "ringan" if condition == "rusak_ringan" else "berat"
+            conn.execute(
+                "UPDATE item_unit SET status='Rusak', defect_level=? WHERE id_code=?",
+                (level, id_code),
+            )
+
+        left = conn.execute(
+            """SELECT COUNT(*) c FROM container_item
+                WHERE container_id=? AND voided_at IS NULL AND returned_at IS NULL""",
+            (cid,),
+        ).fetchone()["c"]
+        if left == 0:
+            conn.execute("UPDATE containers SET status='Closed' WHERE id=?", (cid,))
+
         conn.commit()
         return jsonify({"ok": True})
     finally:

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -122,6 +122,12 @@ export const api = {
     return request('POST', `/containers/${encodeURIComponent(cid)}/void_item`, payload)
   },
 
+  // Check-in item returned to warehouse
+  // payload: { id_code: string, condition?: string, damage_note?: string }
+  checkinItem(cid, payload) {
+    return request('POST', `/containers/${encodeURIComponent(cid)}/checkin`, payload)
+  },
+
   // Submit DN → buat snapshot versi (V1, V2, ...)
   submitDN(cid) {
     return request('POST', `/containers/${encodeURIComponent(cid)}/submit_dn`)

--- a/frontend/src/components/ContainerItemsTable.jsx
+++ b/frontend/src/components/ContainerItemsTable.jsx
@@ -20,18 +20,22 @@ export default function ContainerItemsTable({ batches = {}, onVoid }) {
                 <th style={th}>Rak</th>
                 <th style={th}>Kondisi</th>
                 <th style={th}>Waktu</th>
+                <th style={th}>Status</th>
+                <th style={th}>Returned</th>
                 <th style={th}>Aksi</th>
               </tr>
             </thead>
             <tbody>
               {batches[key].map((it, i) => (
-                <tr key={it.id_code + i} style={rowStyle(it.condition)}>
+                <tr key={it.id_code + i} style={rowStyle(it.return_condition)}>
                   <td style={td}>{it.id_code}</td>
                   <td style={td}>{it.name}</td>
                   <td style={td}>{it.model}</td>
                   <td style={td}>{it.rack}</td>
                   <td style={td}>{labelCond(it.condition)}</td>
                   <td style={td}>{it.added_at}</td>
+                  <td style={td}>{it.return_condition ? labelCond(it.return_condition) : 'Out'}</td>
+                  <td style={td}>{it.returned_at || '-'}</td>
                   <td style={td}>
                     <button
                       type="button"

--- a/frontend/src/pages/ContainerDetail.jsx
+++ b/frontend/src/pages/ContainerDetail.jsx
@@ -10,6 +10,9 @@ export default function ContainerDetail(){
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const [dn, setDn] = useState(null) // latest snapshot payload
+  const [scanRet, setScanRet] = useState('')
+  const [retCond, setRetCond] = useState('good')
+  const [retNote, setRetNote] = useState('')
 
   async function refresh(){
     setLoading(true); setError('')
@@ -31,6 +34,16 @@ export default function ContainerDetail(){
       alert(`DN versi ${out.version} dibuat.`)
       await refresh()
     }catch(e){ alert(e.message) }
+  }
+
+  async function doCheckin(e){
+    e.preventDefault()
+    if (!scanRet.trim()) return
+    try{
+      await api.checkinItem(cid,{ id_code: scanRet.trim(), condition: retCond, damage_note: retNote })
+      setScanRet(''); setRetNote(''); setRetCond('good')
+      await refresh()
+    }catch(err){ alert(err.message) }
   }
 
   function printDN(){
@@ -100,6 +113,19 @@ export default function ContainerDetail(){
 
       <div className="noprint">
         <CheckoutAdder cid={cid} onAdded={refresh}/>
+        <form onSubmit={doCheckin} style={{marginTop:16, display:'grid', gap:8, padding:16, border:'1px solid #eee', borderRadius:12}}>
+          <h3>Check-In Barang</h3>
+          <input value={scanRet} onChange={e=>setScanRet(e.target.value)} placeholder="Scan ID" style={{padding:8, border:'1px solid #ddd', borderRadius:8}}/>
+          <select value={retCond} onChange={e=>setRetCond(e.target.value)} style={{padding:8, border:'1px solid #ddd', borderRadius:8}}>
+            <option value="good">Good</option>
+            <option value="rusak_ringan">Rusak ringan</option>
+            <option value="rusak_berat">Rusak berat</option>
+          </select>
+          {retCond !== 'good' && (
+            <input value={retNote} onChange={e=>setRetNote(e.target.value)} placeholder="Catatan kerusakan" style={{padding:8, border:'1px solid #ddd', borderRadius:8}}/>
+          )}
+          <button style={{padding:'10px 14px'}}>Check-In</button>
+        </form>
       </div>
 
       {/* Tabel item per batch (printable) - live view */}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -25,7 +25,7 @@ export default function Dashboard() {
       <ul style={{marginTop:16}}>
         <li><Link to="/inventory">Ke Inventory (Pendaftaran + QR)</Link></li>
         <li><a href="/print-labels">Print QR Labels</a></li>
-        <li><a href="/containers">Kontainer / Checkout</a></li>
+        <li><a href="/containers">Kontainer (Checkout & Check-In)</a></li>
       </ul>
     </div>
   )


### PR DESCRIPTION
## Summary
- track item returns with `returned_at`, `return_condition`, and `damage_note`
- allow check-in via `POST /containers/<cid>/checkin` and update item status
- add check-in form and return status table in container detail UI

## Testing
- `python -m py_compile backend/db.py backend/routes_containers.py`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b56fce78f48333a108573640682616