### PR TITLE
fix: reflect return condition in totals

### DIFF
--- a/backend/routes_containers.py
+++ b/backend/routes_containers.py
@@ -97,7 +97,7 @@ def _build_detail(conn, cid):
             "return_condition": d.get("return_condition"),
             "damage_note": d.get("damage_note"),
         })
-        cond = (d.get("condition_at_checkout") or "good")
+        cond = d.get("return_condition") or d.get("condition_at_checkout") or "good"
         if cond in totals:
             totals[cond] += 1
         totals["all"] += 1


### PR DESCRIPTION
## Summary
- count return_condition when computing container condition totals

## Testing
- `python -m py_compile backend/routes_containers.py`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5809cf1088333ba01a192fd7eda42