### PR TITLE
feat: improve container checkout and check-in flow

### DIFF
--- a/frontend/src/components/ContainerItemsTable.jsx
+++ b/frontend/src/components/ContainerItemsTable.jsx
@@ -18,10 +18,11 @@ export default function ContainerItemsTable({ batches = {}, onVoid }) {
                 <th style={th}>Nama</th>
                 <th style={th}>Model</th>
                 <th style={th}>Rak</th>
-                <th style={th}>Kondisi</th>
-                <th style={th}>Waktu</th>
+                <th style={th}>Kondisi Out</th>
+                <th style={th}>Waktu Out</th>
                 <th style={th}>Status</th>
-                <th style={th}>Returned</th>
+                <th style={th}>Kondisi Return</th>
+                <th style={th}>Waktu Return</th>
                 <th style={th}>Aksi</th>
               </tr>
             </thead>
@@ -34,8 +35,8 @@ export default function ContainerItemsTable({ batches = {}, onVoid }) {
                   <td style={td}>{it.rack}</td>
                   <td style={td}>{labelCond(it.condition)}</td>
                   <td style={td}>{it.added_at}</td>
-                  <td style={td}>{it.return_condition ? (it.return_condition==='good'?'Returned':labelCond(it.return_condition)) : 'Out'}</td>
-                  <td style={td}>{it.return_condition ? labelCond(it.return_condition) : 'Out'}</td>
+                  <td style={td}>{it.return_condition ? 'Returned' : 'Out'}</td>
+                  <td style={td}>{it.return_condition ? labelCond(it.return_condition) : '-'}</td>
                   <td style={td}>{it.returned_at || '-'}</td>
                   <td style={td}>
                     <button

--- a/frontend/src/pages/CheckInList.jsx
+++ b/frontend/src/pages/CheckInList.jsx
@@ -6,7 +6,7 @@ export default function CheckInList(){
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   useEffect(()=>{
-    api.listContainers({status:'Open'}).then(r=>setItems(r.data||[])).catch(e=>setError(e.message)).finally(()=>setLoading(false))
+    api.listContainers({status:'Open', per_page:100}).then(r=>setItems(r.data||[])).catch(e=>setError(e.message)).finally(()=>setLoading(false))
   },[])
   if (loading) return <div style={{padding:24}}>Loading…</div>
   if (error) return <div style={{padding:24,color:'crimson'}}>{error}</div>

--- a/frontend/src/pages/ContainerCheckIn.jsx
+++ b/frontend/src/pages/ContainerCheckIn.jsx
@@ -45,7 +45,7 @@ export default function ContainerCheckIn(){
   if (!data) return <div style={{padding:24}}>Tidak ada data</div>
 
   const c = data.container
-  const t = data.totals || {good:0, rusak_ringan:0, rusak_berat:0, all:0}
+  const t = data.totals || {returned:0, good:0, rusak_ringan:0, rusak_berat:0, all:0}
 
   return (
     <div style={{padding:24, fontFamily:'sans-serif'}}>
@@ -54,7 +54,8 @@ export default function ContainerCheckIn(){
       {/* Counters (live) */}
       <div className="noprint" style={{display:'flex', gap:12, marginBottom:12}}>
         <Badge label="Total" value={t.all}/>
-        <Badge label="Returned" value={t.good}/>
+        <Badge label="Returned" value={t.returned}/>
+        <Badge label="Good" value={t.good}/>
         <Badge label="Ringan" value={t.rusak_ringan} color="#b58900"/>
         <Badge label="Berat" value={t.rusak_berat} color="#c1121f"/>
       </div>
@@ -64,7 +65,6 @@ export default function ContainerCheckIn(){
           <h3>Check-In Barang</h3>
           <input value={scanRet} onChange={e=>setScanRet(e.target.value)} placeholder="Scan ID" style={{padding:8, border:'1px solid #ddd', borderRadius:8}}/>
           <select value={retCond} onChange={e=>setRetCond(e.target.value)} style={{padding:8, border:'1px solid #ddd', borderRadius:8}}>
-            <option value="good">Returned</option>
             <option value="good">Good</option>
             <option value="rusak_ringan">Rusak ringan</option>
             <option value="rusak_berat">Rusak berat</option>

--- a/frontend/src/pages/ContainersPage.jsx
+++ b/frontend/src/pages/ContainersPage.jsx
@@ -7,61 +7,75 @@ export default function ContainersPage(){
   const [q, setQ] = useState('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [page, setPage] = useState(1)
+  const [total, setTotal] = useState(0)
+  const perPage = 20
 
-  async function refresh(){
+  async function refresh(p = page){
     setLoading(true); setError('')
     try{
-      const res = await api.listContainers(q ? { q } : {})
+      const params = { page: p, per_page: perPage }
+      if (q) params.q = q
+      const res = await api.listContainers(params)
       setItems(res.data || [])
+      setTotal(res.total || 0)
+      setPage(res.page || p)
     }catch(e){ setError(e.message) }
     finally{ setLoading(false) }
   }
-  useEffect(()=>{ refresh() }, [])
+  useEffect(()=>{ refresh(page) }, [page])
 
   const ipt = {padding:8, border:'1px solid #ddd', borderRadius:8}
   return (
     <div style={{padding:24, fontFamily:'sans-serif'}}>
-      <h2>Kontainer / Event</h2>
+      <h2>Kontainer</h2>
       <div style={{display:'grid', gridTemplateColumns:'1fr 2fr', gap:24}}>
-        <div><ContainerForm onCreated={() => refresh()} /></div>
+        <div><ContainerForm onCreated={() => refresh(1)} /></div>
         <div>
           <div style={{marginBottom:8, display:'flex', gap:8}}>
             <input value={q} onChange={e=>setQ(e.target.value)} placeholder="Cari id/event/pic/lokasi..." style={{...ipt, flex:1}}/>
-            <button onClick={refresh} style={{padding:'8px 12px'}}>Cari</button>
+            <button onClick={()=>{setPage(1); refresh(1)}} style={{padding:'8px 12px'}}>Cari</button>
           </div>
           {error && <div style={{color:'crimson'}}>{error}</div>}
-          {loading ? 'Loading…' :
-            <div style={{border:'1px solid #eee', borderRadius:12, overflow:'hidden'}}>
-              <table style={{width:'100%', borderCollapse:'collapse'}}>
-                <thead>
-                  <tr style={{background:'#fafafa'}}>
-                    <th style={th}>ID</th>
-                    <th style={th}>Event</th>
-                    <th style={th}>PIC</th>
-                    <th style={th}>Lokasi</th>
-                    <th style={th}>Jadwal</th>
-                    <th style={th}>Status</th>
-                    <th style={th}>Aksi</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {items.length ? items.map((c)=>(
-                    <tr key={c.id}>
-                      <td style={td}>{c.id}</td>
-                      <td style={td}>{c.event_name}</td>
-                      <td style={td}>{c.pic}</td>
-                      <td style={td}>{c.location || '-'}</td>
-                      <td style={td}>{(c.start_date||'-') + ' → ' + (c.end_date||'-')}</td>
-                      <td style={td}>{c.status}</td>
-                      <td style={td}><a href={`/containers/${c.id}/checkout`}>Buka</a></td>
+          {loading ? 'Loading…' : (
+            <div>
+              <div style={{border:'1px solid #eee', borderRadius:12, overflow:'hidden'}}>
+                <table style={{width:'100%', borderCollapse:'collapse'}}>
+                  <thead>
+                    <tr style={{background:'#fafafa'}}>
+                      <th style={th}>ID</th>
+                      <th style={th}>Event</th>
+                      <th style={th}>PIC</th>
+                      <th style={th}>Lokasi</th>
+                      <th style={th}>Jadwal</th>
+                      <th style={th}>Status</th>
+                      <th style={th}>Aksi</th>
                     </tr>
-                  )):(
-                    <tr><td style={td} colSpan={7}>Belum ada kontainer</td></tr>
-                  )}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {items.length ? items.map((c)=>(
+                      <tr key={c.id}>
+                        <td style={td}>{c.id}</td>
+                        <td style={td}>{c.event_name}</td>
+                        <td style={td}>{c.pic}</td>
+                        <td style={td}>{c.location || '-'}</td>
+                        <td style={td}>{(c.start_date||'-') + ' → ' + (c.end_date||'-')}</td>
+                        <td style={td}>{c.status}</td>
+                        <td style={td}>{c.status === 'Open' ? <a href={`/containers/${c.id}/checkout`}>Buka</a> : '-'}</td>
+                      </tr>
+                    )):(
+                      <tr><td style={td} colSpan={7}>Belum ada kontainer</td></tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+              <div style={{marginTop:8, display:'flex', justifyContent:'space-between', alignItems:'center'}}>
+                <button disabled={page<=1} onClick={()=>setPage(p=>p-1)} style={{padding:'6px 12px'}}>Prev</button>
+                <div>Hal {page} / {Math.max(1, Math.ceil(total / perPage))}</div>
+                <button disabled={page>=Math.ceil(total/perPage)} onClick={()=>setPage(p=>p+1)} style={{padding:'6px 12px'}}>Next</button>
+              </div>
             </div>
-          }
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -27,7 +27,7 @@ export default function Dashboard() {
         <li><a href="/print-labels">Print QR Labels</a></li>
         <li><Link to="/containers">Check-Out</Link></li>
         <li><Link to="/checkin">Check-In</Link></li>
-        <li><a href="/containers">Kontainer (Checkout & Check-In)</a></li>
+        <li><Link to="/containers">Kontainer</Link></li>
       </ul>
     </div>
   )


### PR DESCRIPTION
## Summary
- add pagination and status-aware actions on containers list
- track returned items in container detail and UI
- refine check-in UI with detailed counters and return options

## Testing
- `npm test` (fails: Missing script "test")
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a1e0f8548333a3f4c18258489b98