### PR TITLE
Improve manual input layout in check-in forms

### DIFF
--- a/frontend/src/pages/ContainerCheckIn.jsx
+++ b/frontend/src/pages/ContainerCheckIn.jsx
@@ -13,6 +13,7 @@ export default function ContainerCheckIn(){
   const [retCond, setRetCond] = useState('good')
   const [retNote, setRetNote] = useState('')
   const scanRef = useRef(null)
+  const ipt = { padding:8, border:'1px solid #ddd', borderRadius:8, width:'100%' }
 
   async function refresh(){
     setLoading(true); setError('')
@@ -72,11 +73,11 @@ export default function ContainerCheckIn(){
       <div className="noprint">
         <form onSubmit={doCheckin} style={{marginTop:16, display:'grid', gap:8, padding:16, border:'1px solid #eee', borderRadius:12}}>
           <h3>Check-In Barang</h3>
-          <input ref={scanRef} autoFocus value={scanRet} onChange={e=>setScanRet(e.target.value)} placeholder="Scan ID" style={{padding:8, border:'1px solid #ddd', borderRadius:8}}/>
-          <label>Input manual (satu ID per baris)
-            <textarea value={listIds} onChange={e=>setListIds(e.target.value)} style={{padding:8, border:'1px solid #ddd', borderRadius:8, height:100}} placeholder="CAM-70D-002&#10;CAM-70D-003"></textarea>
+          <input ref={scanRef} autoFocus value={scanRet} onChange={e=>setScanRet(e.target.value)} placeholder="Scan ID" style={ipt}/>
+          <label style={{display:'grid', gap:4}}>Input manual (satu ID per baris)
+            <textarea value={listIds} onChange={e=>setListIds(e.target.value)} style={{...ipt, height:120}} placeholder="CAM-70D-002&#10;CAM-70D-003"></textarea>
           </label>
-          <select value={retCond} onChange={e=>setRetCond(e.target.value)} style={{padding:8, border:'1px solid #ddd', borderRadius:8}}>
+          <select value={retCond} onChange={e=>setRetCond(e.target.value)} style={ipt}>
             <option value="good">Good</option>
             <option value="rusak_ringan">Rusak ringan</option>
             <option value="rusak_berat">Rusak berat</option>

--- a/frontend/src/pages/ContainerDetail.jsx
+++ b/frontend/src/pages/ContainerDetail.jsx
@@ -15,6 +15,7 @@ export default function ContainerDetail(){
   const [retCond, setRetCond] = useState('good')
   const [retNote, setRetNote] = useState('')
   const scanRef = useRef(null)
+  const ipt = { padding:8, border:'1px solid #ddd', borderRadius:8, width:'100%' }
 
   async function refresh(){
     setLoading(true); setError('')
@@ -123,11 +124,11 @@ export default function ContainerDetail(){
         <CheckoutAdder cid={cid} onAdded={refresh}/>
         <form onSubmit={doCheckin} style={{marginTop:16, display:'grid', gap:8, padding:16, border:'1px solid #eee', borderRadius:12}}>
           <h3>Check-In Barang</h3>
-          <input ref={scanRef} autoFocus value={scanRet} onChange={e=>setScanRet(e.target.value)} placeholder="Scan ID" style={{padding:8, border:'1px solid #ddd', borderRadius:8}}/>
-          <label>Input manual (satu ID per baris)
-            <textarea value={listIds} onChange={e=>setListIds(e.target.value)} style={{padding:8, border:'1px solid #ddd', borderRadius:8, height:100}} placeholder="CAM-70D-002&#10;CAM-70D-003"></textarea>
+          <input ref={scanRef} autoFocus value={scanRet} onChange={e=>setScanRet(e.target.value)} placeholder="Scan ID" style={ipt}/>
+          <label style={{display:'grid', gap:4}}>Input manual (satu ID per baris)
+            <textarea value={listIds} onChange={e=>setListIds(e.target.value)} style={{...ipt, height:120}} placeholder="CAM-70D-002&#10;CAM-70D-003"></textarea>
           </label>
-          <select value={retCond} onChange={e=>setRetCond(e.target.value)} style={{padding:8, border:'1px solid #ddd', borderRadius:8}}>
+          <select value={retCond} onChange={e=>setRetCond(e.target.value)} style={ipt}>
             <option value="good">Returned</option>
             <option value="good">Good</option>
             <option value="rusak_ringan">Rusak ringan</option>


### PR DESCRIPTION
## Summary
- Ensure manual ID entry fields sit below scan inputs on check-in pages
- Match manual input styling to checkout with larger textarea and full-width controls

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5aa6f8da48333ae0490f29b91ee5c