### PR TITLE
Show container details during check-in and checkout

### DIFF
--- a/frontend/src/pages/CheckInList.jsx
+++ b/frontend/src/pages/CheckInList.jsx
@@ -14,18 +14,33 @@ export default function CheckInList(){
     <div style={{padding:24,fontFamily:'sans-serif'}}>
       <h2>Check-In</h2>
       <table style={{width:'100%',borderCollapse:'collapse'}}>
-        <thead><tr style={{background:'#fafafa'}}>
-          <th style={th}>ID</th><th style={th}>Event</th><th style={th}>PIC</th><th style={th}>Aksi</th>
-        </tr></thead>
+        <thead>
+          <tr style={{background:'#fafafa'}}>
+            <th style={th}>ID</th>
+            <th style={th}>Event</th>
+            <th style={th}>PIC</th>
+            <th style={th}>Crew</th>
+            <th style={th}>Lokasi</th>
+            <th style={th}>Jadwal</th>
+            <th style={th}>Aksi</th>
+          </tr>
+        </thead>
         <tbody>
-          {items.length? items.map(c=> (
-            <tr key={c.id}>
-              <td style={td}>{c.id}</td>
-              <td style={td}>{c.event_name}</td>
-              <td style={td}>{c.pic}</td>
-              <td style={td}><a href={`/containers/${c.id}/checkin`}>Buka</a></td>
-            </tr>
-          )): <tr><td style={td} colSpan={4}>Tidak ada kontainer</td></tr>}
+          {items.length ? (
+            items.map(c => (
+              <tr key={c.id}>
+                <td style={td}>{c.id}</td>
+                <td style={td}>{c.event_name}</td>
+                <td style={td}>{c.pic}</td>
+                <td style={td}>{c.crew || '-'}</td>
+                <td style={td}>{c.location || '-'}</td>
+                <td style={td}>{(c.start_date||'-') + ' → ' + (c.end_date||'-')}</td>
+                <td style={td}><a href={`/containers/${c.id}/checkin`}>Buka</a></td>
+              </tr>
+            ))
+          ) : (
+            <tr><td style={td} colSpan={7}>Tidak ada kontainer</td></tr>
+          )}
         </tbody>
       </table>
     </div>

--- a/frontend/src/pages/ContainerCheckIn.jsx
+++ b/frontend/src/pages/ContainerCheckIn.jsx
@@ -60,6 +60,13 @@ export default function ContainerCheckIn(){
   return (
     <div style={{padding:24, fontFamily:'sans-serif'}}>
       <h2>Kontainer: {c.id}</h2>
+      <div style={{marginBottom:16}}>
+        <div><b>Event:</b> {c.event_name}</div>
+        <div><b>PIC:</b> {c.pic}</div>
+        <div><b>Crew:</b> {c.crew || '-'}</div>
+        <div><b>Lokasi:</b> {c.location || '-'}</div>
+        <div><b>Jadwal:</b> {(c.start_date || '-') + ' → ' + (c.end_date || '-')}</div>
+      </div>
 
       {/* Counters (live) */}
       <div className="noprint" style={{display:'flex', gap:12, marginBottom:12}}>

--- a/frontend/src/pages/ContainerCheckout.jsx
+++ b/frontend/src/pages/ContainerCheckout.jsx
@@ -37,6 +37,13 @@ export default function ContainerCheckout(){
   return (
     <div style={{padding:24, fontFamily:'sans-serif'}}>
       <h2>Kontainer: {c.id}</h2>
+      <div style={{marginBottom:16}}>
+        <div><b>Event:</b> {c.event_name}</div>
+        <div><b>PIC:</b> {c.pic}</div>
+        <div><b>Crew:</b> {c.crew || '-'}</div>
+        <div><b>Lokasi:</b> {c.location || '-'}</div>
+        <div><b>Jadwal:</b> {(c.start_date || '-') + ' → ' + (c.end_date || '-')}</div>
+      </div>
       <div className="noprint">
         <CheckoutAdder cid={cid} onAdded={refresh}/>
       </div>


### PR DESCRIPTION
## Summary
- display event, PIC, crew, location, and schedule on check-in list
- show container details on checkout page
- show container details on check-in page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`
- `python -m compileall backend`


------
https://chatgpt.com/codex/tasks/task_e_68b5e04216848333be86e063ab94f7bc