### PR TITLE
Add Indonesian-friendly date/time formatting

### DIFF
--- a/frontend/src/components/ContainerItemsTable.jsx
+++ b/frontend/src/components/ContainerItemsTable.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { formatDateTime } from '../utils/date.js'
 
 export default function ContainerItemsTable({ batches = {}, onVoid }) {
   const keys = Object.keys(batches).sort()
@@ -34,10 +35,10 @@ export default function ContainerItemsTable({ batches = {}, onVoid }) {
                   <td style={td}>{it.model}</td>
                   <td style={td}>{it.rack}</td>
                   <td style={td}>{labelCond(it.condition)}</td>
-                  <td style={td}>{it.added_at}</td>
+                  <td style={td}>{formatDateTime(it.added_at, {monthText:true})}</td>
                   <td style={td}>{it.return_condition ? 'Returned' : 'Out'}</td>
                   <td style={td}>{it.return_condition ? labelCond(it.return_condition) : '-'}</td>
-                  <td style={td}>{it.returned_at || '-'}</td>
+                  <td style={td}>{it.returned_at ? formatDateTime(it.returned_at, {monthText:true}) : '-'}</td>
                   <td style={td}>
                     <button
                       type="button"

--- a/frontend/src/pages/CheckInList.jsx
+++ b/frontend/src/pages/CheckInList.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { api } from '../api.js'
+import { formatDateTime } from '../utils/date.js'
 
 export default function CheckInList(){
   const [items, setItems] = useState([])
@@ -21,7 +22,8 @@ export default function CheckInList(){
             <th style={th}>PIC</th>
             <th style={th}>Crew</th>
             <th style={th}>Lokasi</th>
-            <th style={th}>Jadwal</th>
+            <th style={th}>Mulai</th>
+            <th style={th}>Selesai</th>
             <th style={th}>Aksi</th>
           </tr>
         </thead>
@@ -34,12 +36,13 @@ export default function CheckInList(){
                 <td style={td}>{c.pic}</td>
                 <td style={td}>{c.crew || '-'}</td>
                 <td style={td}>{c.location || '-'}</td>
-                <td style={td}>{(c.start_date||'-') + ' → ' + (c.end_date||'-')}</td>
+                <td style={td}>{formatDateTime(c.start_date, {monthText:true})}</td>
+                <td style={td}>{formatDateTime(c.end_date, {monthText:true})}</td>
                 <td style={td}><a href={`/containers/${c.id}/checkin`}>Buka</a></td>
               </tr>
             ))
           ) : (
-            <tr><td style={td} colSpan={7}>Tidak ada kontainer</td></tr>
+            <tr><td style={td} colSpan={8}>Tidak ada kontainer</td></tr>
           )}
         </tbody>
       </table>

--- a/frontend/src/pages/ContainerCheckIn.jsx
+++ b/frontend/src/pages/ContainerCheckIn.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { api } from '../api.js'
 import ContainerItemsTable from '../components/ContainerItemsTable.jsx'
+import { formatDateTime } from '../utils/date.js'
 
 export default function ContainerCheckIn(){
   const { cid } = useParams()
@@ -65,7 +66,8 @@ export default function ContainerCheckIn(){
         <div><b>PIC:</b> {c.pic}</div>
         <div><b>Crew:</b> {c.crew || '-'}</div>
         <div><b>Lokasi:</b> {c.location || '-'}</div>
-        <div><b>Jadwal:</b> {(c.start_date || '-') + ' → ' + (c.end_date || '-')}</div>
+        <div><b>Mulai:</b> {formatDateTime(c.start_date, {monthText:true})}</div>
+        <div><b>Selesai:</b> {formatDateTime(c.end_date, {monthText:true})}</div>
       </div>
 
       {/* Counters (live) */}

--- a/frontend/src/pages/ContainerCheckout.jsx
+++ b/frontend/src/pages/ContainerCheckout.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import { api } from '../api.js'
 import CheckoutAdder from '../components/CheckoutAdder.jsx'
 import ContainerItemsTable from '../components/ContainerItemsTable.jsx'
+import { formatDateTime } from '../utils/date.js'
 
 export default function ContainerCheckout(){
   const { cid } = useParams()
@@ -42,7 +43,8 @@ export default function ContainerCheckout(){
         <div><b>PIC:</b> {c.pic}</div>
         <div><b>Crew:</b> {c.crew || '-'}</div>
         <div><b>Lokasi:</b> {c.location || '-'}</div>
-        <div><b>Jadwal:</b> {(c.start_date || '-') + ' → ' + (c.end_date || '-')}</div>
+        <div><b>Mulai:</b> {formatDateTime(c.start_date, {monthText:true})}</div>
+        <div><b>Selesai:</b> {formatDateTime(c.end_date, {monthText:true})}</div>
       </div>
       <div className="noprint">
         <CheckoutAdder cid={cid} onAdded={refresh}/>

--- a/frontend/src/pages/ContainerDetail.jsx
+++ b/frontend/src/pages/ContainerDetail.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import { api } from '../api.js'
 import CheckoutAdder from '../components/CheckoutAdder.jsx'
 import ContainerItemsTable from '../components/ContainerItemsTable.jsx'
+import { formatDateTime } from '../utils/date.js'
 
 export default function ContainerDetail(){
   const { cid } = useParams()
@@ -91,9 +92,11 @@ export default function ContainerDetail(){
       <div style={{border:'1px solid #eee', borderRadius:12, padding:16, marginBottom:16}}>
         <div style={{fontSize:18, fontWeight:700, marginBottom:8}}>Delivery Note</div>
         <div><b>Event:</b> {c.event_name}</div>
-        <div><b>PIC:</b> {c.pic} {c.crew ? `· Crew: ${c.crew}` : ''}</div>
+        <div><b>PIC:</b> {c.pic}</div>
+        <div><b>Crew:</b> {c.crew || '-'}</div>
         <div><b>Lokasi:</b> {c.location || '-'}</div>
-        <div><b>Jadwal:</b> {(c.start_date||'-')} → {(c.end_date||'-')}</div>
+        <div><b>Mulai:</b> {formatDateTime(c.start_date, {monthText:true})}</div>
+        <div><b>Selesai:</b> {formatDateTime(c.end_date, {monthText:true})}</div>
         <div><b>Status:</b> {c.status}</div>
 
         {/* PERHATIAN box jika ada rusak */}

--- a/frontend/src/pages/ContainersPage.jsx
+++ b/frontend/src/pages/ContainersPage.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { api } from '../api.js'
 import ContainerForm from '../components/ContainerForm.jsx'
+import { formatDateTime } from '../utils/date.js'
 
 export default function ContainersPage(){
   const [items, setItems] = useState([])
@@ -47,7 +48,8 @@ export default function ContainersPage(){
                       <th style={th}>Event</th>
                       <th style={th}>PIC</th>
                       <th style={th}>Lokasi</th>
-                      <th style={th}>Jadwal</th>
+                      <th style={th}>Mulai</th>
+                      <th style={th}>Selesai</th>
                       <th style={th}>Status</th>
                       <th style={th}>Aksi</th>
                     </tr>
@@ -59,12 +61,13 @@ export default function ContainersPage(){
                         <td style={td}>{c.event_name}</td>
                         <td style={td}>{c.pic}</td>
                         <td style={td}>{c.location || '-'}</td>
-                        <td style={td}>{(c.start_date||'-') + ' → ' + (c.end_date||'-')}</td>
+                        <td style={td}>{formatDateTime(c.start_date, {monthText:true})}</td>
+                        <td style={td}>{formatDateTime(c.end_date, {monthText:true})}</td>
                         <td style={td}>{c.status}</td>
                         <td style={td}>{c.status === 'Open' ? <a href={`/containers/${c.id}/checkout`}>Buka</a> : '-'}</td>
                       </tr>
                     )):(
-                      <tr><td style={td} colSpan={7}>Belum ada kontainer</td></tr>
+                      <tr><td style={td} colSpan={8}>Belum ada kontainer</td></tr>
                     )}
                   </tbody>
                 </table>

--- a/frontend/src/utils/date.js
+++ b/frontend/src/utils/date.js
@@ -1,0 +1,38 @@
+export function formatDateTime(dateStr, { monthText = false, tzLabel = 'WIB' } = {}) {
+  if (!dateStr) return '-'
+  const d = new Date(dateStr)
+  if (isNaN(d)) return dateStr
+  const day = new Intl.DateTimeFormat('id-ID', { day: '2-digit' }).format(d)
+  const month = new Intl.DateTimeFormat('id-ID', { month: monthText ? 'long' : '2-digit' }).format(d)
+  const year = new Intl.DateTimeFormat('id-ID', { year: '2-digit' }).format(d)
+  const datePart = `${day}-${month}-${year}`
+  const timePart = new Intl.DateTimeFormat('id-ID', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(d).replace('.', ':')
+  return `${datePart} ${timePart}${tzLabel ? ' ' + tzLabel : ''}`
+}
+
+export function formatDate(dateStr, opts = {}) {
+  const { monthText = false } = opts
+  if (!dateStr) return '-'
+  const d = new Date(dateStr)
+  if (isNaN(d)) return dateStr
+  const day = new Intl.DateTimeFormat('id-ID', { day: '2-digit' }).format(d)
+  const month = new Intl.DateTimeFormat('id-ID', { month: monthText ? 'long' : '2-digit' }).format(d)
+  const year = new Intl.DateTimeFormat('id-ID', { year: '2-digit' }).format(d)
+  return `${day}-${month}-${year}`
+}
+
+export function formatTime(dateStr, { tzLabel = 'WIB' } = {}) {
+  if (!dateStr) return '-'
+  const d = new Date(dateStr)
+  if (isNaN(d)) return dateStr
+  const timePart = new Intl.DateTimeFormat('id-ID', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(d).replace('.', ':')
+  return tzLabel ? `${timePart} ${tzLabel}` : timePart
+}


### PR DESCRIPTION
## Summary
- add `formatDateTime` helper to show dates as `dd-Bulan-yy HH:mm WIB`
- use the helper across container pages and tables for more readable schedules and timestamps
- separate day, month, and year with `-` instead of `/`
- surface event, PIC, crew, location, start, and finish on check-in/out pages and container lists for easy double checks

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5e294905883339df699bd91dc2c3a