### PR TITLE
feat: split schedule into start and end columns

### DIFF
--- a/frontend/src/pages/CheckInList.jsx
+++ b/frontend/src/pages/CheckInList.jsx
@@ -22,7 +22,8 @@ export default function CheckInList(){
             <th style={th}>PIC</th>
             <th style={th}>Crew</th>
             <th style={th}>Lokasi</th>
-            <th style={th}>Jadwal</th>
+            <th style={th}>Mulai</th>
+            <th style={th}>Selesai</th>
             <th style={th}>Aksi</th>
           </tr>
         </thead>
@@ -35,12 +36,13 @@ export default function CheckInList(){
                 <td style={td}>{c.pic}</td>
                 <td style={td}>{c.crew || '-'}</td>
                 <td style={td}>{c.location || '-'}</td>
-                <td style={td}>{formatDateTime(c.start_date, {monthText:true}) + ' → ' + formatDateTime(c.end_date, {monthText:true})}</td>
+                <td style={td}>{formatDateTime(c.start_date, {monthText:true})}</td>
+                <td style={td}>{formatDateTime(c.end_date, {monthText:true})}</td>
                 <td style={td}><a href={`/containers/${c.id}/checkin`}>Buka</a></td>
               </tr>
             ))
           ) : (
-            <tr><td style={td} colSpan={7}>Tidak ada kontainer</td></tr>
+            <tr><td style={td} colSpan={8}>Tidak ada kontainer</td></tr>
           )}
         </tbody>
       </table>

--- a/frontend/src/pages/ContainersPage.jsx
+++ b/frontend/src/pages/ContainersPage.jsx
@@ -48,7 +48,8 @@ export default function ContainersPage(){
                       <th style={th}>Event</th>
                       <th style={th}>PIC</th>
                       <th style={th}>Lokasi</th>
-                      <th style={th}>Jadwal</th>
+                      <th style={th}>Mulai</th>
+                      <th style={th}>Selesai</th>
                       <th style={th}>Status</th>
                       <th style={th}>Aksi</th>
                     </tr>
@@ -60,12 +61,13 @@ export default function ContainersPage(){
                         <td style={td}>{c.event_name}</td>
                         <td style={td}>{c.pic}</td>
                         <td style={td}>{c.location || '-'}</td>
-                        <td style={td}>{formatDateTime(c.start_date, {monthText:true}) + ' → ' + formatDateTime(c.end_date, {monthText:true})}</td>
+                        <td style={td}>{formatDateTime(c.start_date, {monthText:true})}</td>
+                        <td style={td}>{formatDateTime(c.end_date, {monthText:true})}</td>
                         <td style={td}>{c.status}</td>
                         <td style={td}>{c.status === 'Open' ? <a href={`/containers/${c.id}/checkout`}>Buka</a> : '-'}</td>
                       </tr>
                     )):(
-                      <tr><td style={td} colSpan={7}>Belum ada kontainer</td></tr>
+                      <tr><td style={td} colSpan={8}>Belum ada kontainer</td></tr>
                     )}
                   </tbody>
                 </table>


### PR DESCRIPTION
## Summary
- show separate Mulai/Selesai columns on check-in list
- show separate Mulai/Selesai columns on container list page

## Testing
- `npm --prefix frontend test` (fails: Missing script: "test")
- `npm --prefix frontend run build`
- `cd backend && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5ef150e008333b49c1e4bab557ee7